### PR TITLE
removed a pitfall where a built-in name was being shadowed

### DIFF
--- a/a08_predict_ensemble.py
+++ b/a08_predict_ensemble.py
@@ -75,8 +75,8 @@ def main(_):
     test= load_data_predict(vocabulary_word2index,vocabulary_word2index_label,questionid_question_lists)
     testX=[]
     question_id_list=[]
-    for tuple in test:
-        question_id,question_string_list=tuple
+    for data in test:
+        question_id,question_string_list=data
         question_id_list.append(question_id)
         testX.append(question_string_list)
     # 2.Data preprocessing: Sequence padding


### PR DESCRIPTION
**The problem**
There was a scenario on the code where a Python built-in name was being shadowed.
It's a good practice to never replace built-in methods with variables, since it may lead to hard-to-detect bugs in a scenario where the name gets invoked bearing in mind its built-in purpose instead of the newly shadowed purpose.

**Solution**
Changed the variable name 